### PR TITLE
Fix es6 exports/imports in entity files

### DIFF
--- a/src/app3-es6/entity/CategorySchema.js
+++ b/src/app3-es6/entity/CategorySchema.js
@@ -1,7 +1,7 @@
 const EntitySchema = require("typeorm").EntitySchema; // import {EntitySchema} from "typeorm";
 const Category = require("../model/Category").Category; // import {Category} from "../model/Category";
 
-module.exports = new EntitySchema({
+/*export */ const CategorySchema = new EntitySchema({
     name: "Category",
     target: Category,
     columns: {
@@ -15,3 +15,7 @@ module.exports = new EntitySchema({
         }
     }
 });
+
+module.exports = {
+    CategorySchema: CategorySchema
+};

--- a/src/app3-es6/entity/PostSchema.js
+++ b/src/app3-es6/entity/PostSchema.js
@@ -2,7 +2,7 @@ const EntitySchema = require("typeorm").EntitySchema; // import {EntitySchema} f
 const Post = require("../model/Post").Post; // import {Post} from "../model/Post";
 const Category = require("../model/Category").Category; // import {Category} from "../model/Category";
 
-module.exports = new EntitySchema({
+/*export */ const PostSchema = new EntitySchema({
     name: "Post",
     target: Post,
     columns: {
@@ -27,3 +27,7 @@ module.exports = new EntitySchema({
         }
     }
 });
+
+module.exports = {
+    PostSchema: PostSchema
+};

--- a/src/app3-es6/index.js
+++ b/src/app3-es6/index.js
@@ -1,6 +1,9 @@
 const typeorm = require("typeorm"); // import * as typeorm from "typeorm";
 const Post = require("./model/Post").Post; // import {Post} from "./model/Post";
 const Category = require("./model/Category").Category; // import {Category} from "./model/Category";
+const PostSchema = require("./entity/PostSchema").PostSchema; // import {PostSchema} from "./entity/PostSchema";
+const CategorySchema = require("./entity/CategorySchema").CategorySchema; // import {CategorySchema} from "./entity/CategorySchema";
+
 
 typeorm.createConnection({
     type: "mysql",
@@ -12,8 +15,8 @@ typeorm.createConnection({
     synchronize: true,
     logging: false,
     entities: [
-        require("./entity/PostSchema"),
-        require("./entity/CategorySchema")
+        PostSchema,
+        CategorySchema
     ]
 }).then(function (connection) {
 


### PR DESCRIPTION
I have some friends using this guide right now to learn how to use `typeorm` without `typescript`, but with `babel`. The `/* export */` and `// import ... ` comments are useful for those using es6. However, they weren't used in the entity files.

Being that `export default` is actually `module.exports.default`, that would make the commonjs version a bit more confusing than just using a named export after the entity. Although, this keeps consistency with the model files already using named exports.